### PR TITLE
Fix: guard missing checkCurrentIsDbGraph API to avoid handshake crash

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,13 @@ const main = async () => {
   await logseq.UI.showMsg('logseq-datenlp-plugin loaded')
 
   // Check if DB version is being used
-  const isDb = await logseq.App.checkCurrentIsDbGraph()
+  let isDb = false
+  try {
+    isDb = await logseq.App.checkCurrentIsDbGraph()
+  } catch {
+    // Host doesn't expose the method → treat as non-DB graph
+    isDb = false
+  }
 
   handlePopupAndInputFocus()
 


### PR DESCRIPTION
On some Logseq builds, `App.checkCurrentIsDbGraph` is not exported by the host, which causes the plugin to crash at load time with:

```
Not existed method #checkCurrentIsDbGraph
```

This change wraps the call in a `try/catch` block and falls back to `false` when the API is unavailable. This prevents the plugin from failing during initialization while preserving existing behavior on builds where the method is supported.

Investigation and patch were developed with assistance from ChatGPT.

No other behavior is modified. 
Also I couldnt install bunx due to not having room for the xcode update so I couldn't run the lint/test suite but the fix is maybe simple enough?