### PR TITLE
Fix week button to follow current journal page and update on route change

### DIFF
--- a/src/features/toolbar/helpers.ts
+++ b/src/features/toolbar/helpers.ts
@@ -18,7 +18,15 @@ const startOfWeekMap: Record<StartDayOfWeek, Day> = {
   Saturday: 6,
 }
 
+export const getCurrentPageDate = async (): Promise<Date> => {
+  const currPage = await logseq.Editor.getCurrentPage()
+  return currPage?.journalDay
+    ? parse((currPage.journalDay as number).toString(), 'yyyyMMdd', new Date())
+    : new Date()
+}
+
 export const helpers = {
+
   previousDayName: async () => {
     const currPage = await logseq.Editor.getCurrentPage()
     const currPageDate = currPage?.journalDay


### PR DESCRIPTION
The week button previously:

- Always computed the week using `new Date()`
- Displayed the current week number even when browsing older journal entries

This change:

- Computes the week based on the active journal page (`journalDay`) when available
- Falls back to the current date when not on a journal page
- Updates the toolbar label on route changes to reflect the current context

This ensures consistent behavior between the displayed week and the page that is opened when clicking the button.